### PR TITLE
Octoprint 2.0.0 fixes

### DIFF
--- a/octoprint_extrafileinfo/__init__.py
+++ b/octoprint_extrafileinfo/__init__.py
@@ -57,6 +57,9 @@ class ExtraFileInfoPlugin(
             enable_defaultdict=False,
             custom_template=""
         )
+
+    def is_api_protected(self):
+        return True
     
     def get_api_commands(self):
         return {

--- a/octoprint_extrafileinfo/__init__.py
+++ b/octoprint_extrafileinfo/__init__.py
@@ -5,10 +5,12 @@ import os.path as ospath
 import re
 from collections import defaultdict
 
+import flask
 import octoprint.plugin
 from jinja2 import FileSystemLoader, TemplateSyntaxError
 from jinja2.environment import Template
 from jinja2.sandbox import SandboxedEnvironment, SecurityError
+from octoprint.access.permissions import Permissions
 from octoprint.filemanager.storage import LocalFileStorage
 
 SETUP_SIMPLE = 'Simple'
@@ -197,9 +199,7 @@ class ExtraFileInfoPlugin(
         recurse(files)
 
     def on_api_command(self, command, _):
-        import flask
-        from octoprint.server import user_permission
-        if not user_permission.can():
+        if not Permissions.SETTINGS.can():
             return flask.make_response("Insufficient rights", 401)
         
         if command == 'force_render':

--- a/octoprint_extrafileinfo/__init__.py
+++ b/octoprint_extrafileinfo/__init__.py
@@ -134,6 +134,9 @@ class ExtraFileInfoPlugin(
         return [
             dict(type="settings", template="extrafileinfo_settings.jinja2", custom_bindings=True)
         ]
+
+    def is_template_autoescaped(self):
+        return True
     
     def on_event(self, event: str, payload: dict):
         if event == 'plugin_SlicerSettingsParser_file_analyzed':


### PR DESCRIPTION
This is the same as #22 but without the `pyproject.toml` migration point, which was optional and caused installation issues (#23).